### PR TITLE
Fix cropped image for the twitter card

### DIFF
--- a/src/chromium.ts
+++ b/src/chromium.ts
@@ -18,7 +18,7 @@ export async function getScreenshot(
   isDev: boolean
 ) {
   const page = await getPage(isDev)
-  await page.setViewport({ width: 1200, height: 685 })
+  await page.setViewport({ width: 1200, height: 628 })
   await page.goto(url)
   const file = await page.screenshot({ type })
   return file


### PR DESCRIPTION
issue:
![Image from iOS](https://user-images.githubusercontent.com/1519448/62156894-93afca80-b314-11e9-8bda-4adf465d18aa.jpg)


Seems setting up 1.91/1 aspect ratio (1200x628) instead of 1.75 (1200x685) fixes the issue.
Actual twitter card sizes described here: https://louisem.com/217438/twitter-image-size